### PR TITLE
Bump alpha-ess to 1.1.1 at stable

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -96,7 +96,7 @@
     "meta": "https://raw.githubusercontent.com/Gaspode69/ioBroker.alpha-ess/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/Gaspode69/ioBroker.alpha-ess/main/admin/alpha-ess.png",
     "type": "energy",
-    "version": "1.0.2"
+    "version": "1.1.1"
   },
   "alpha2": {
     "meta": "https://raw.githubusercontent.com/Eisbaeeer/ioBroker.alpha2/master/io-package.json",


### PR DESCRIPTION
Der Hersteller hat mal wieder ohne Ankündigung die URI geändert, daher wäre es ziemlich eilig, dass Version 1.1.1 in Stable kommt. Danke!